### PR TITLE
fix: install stageplay from GitHub

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "vite build ./src/ --outDir ../dist/ --base \"/netrunner-online/\""
   },
   "dependencies": {
-    "stageplay": "file:../stageplay"
+    "stageplay": "github:mzpkdev/stageplay"
   },
   "devDependencies": {
     "vite": "^6.3.4"


### PR DESCRIPTION
Update stageplay dependency to install from https://github.com/mzpkdev/stageplay instead of a local file:// path.

Closes #3

Generated with [Claude Code](https://claude.ai/code)