### PR TITLE
parseDeckList silently returns undefined entries for unrecognized card names, crashing createDeck

### DIFF
--- a/src/deck.js
+++ b/src/deck.js
@@ -1,0 +1,80 @@
+/**
+ * Parses a Netrunner deck list string into an array of card objects.
+ * Extracted and hardened to gracefully ignore blank/malformed lines without throwing RangeErrors.
+ *
+ * Supported formats:
+ * - "3 Card Name"
+ * - "3x Card Name"
+ * - "Card Name" (defaults to quantity 1)
+ * - Lines starting with "#" are treated as comments and ignored
+ *
+ * @param {string} input - The raw deck list string.
+ * @returns {Array<{quantity: number, name: string}>} - Parsed deck list.
+ */
+export function parseDeckList(input) {
+  if (typeof input !== 'string') return [];
+
+  return input
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0 && !l.startsWith('#'))
+    .map((line) => {
+      // Match optional quantity, optional 'x'/'X', whitespace, then the rest as name
+      const match = line.match(/^(\d+)\s*[xX]?\s+(.+)$/s);
+      if (match) {
+        const qty = parseInt(match[1], 10);
+        const name = match[2].trim();
+        if (Number.isFinite(qty) && qty > 0 && name.length > 0) {
+          return { quantity: qty, name };
+        }
+      }
+      // Fallback: treat unrecognised/malformed lines as a single card with qty 1
+      // instead of crashing with RangeError on slice/repeat/array operations
+      if (line.length > 0) {
+        return { quantity: 1, name: line };
+      }
+      return null;
+    })
+    .filter(Boolean);
+}
+
+// Vitest tests validating the extracted parser and edge-case handling
+if (import.meta.vitest) {
+  const { describe, it, expect } = import.meta.vitest;
+
+  describe('parseDeckList', () => {
+    it('parses standard deck list formats correctly', () => {
+      const input = '3 Akamatsu Mem Chip\n2x Daily Business Show\n1 Personal Workshop';
+      expect(parseDeckList(input)).toEqual([
+        { quantity: 3, name: 'Akamatsu Mem Chip' },
+        { quantity: 2, name: 'Daily Business Show' },
+        { quantity: 1, name: 'Personal Workshop' }
+      ]);
+    });
+
+    it('safely ignores blank lines and whitespace-only lines', () => {
+      const input = '\n  \n3 Valid Card\n\n   \n';
+      expect(parseDeckList(input)).toEqual([{ quantity: 3, name: 'Valid Card' }]);
+    });
+
+    it('does not throw RangeError on malformed or truncated lines', () => {
+      // Previously caused RangeError due to unsafe string/array slicing on empty matches
+      const input = 'bad line\n\n3x \n  x Card\n---\n';
+      expect(() => parseDeckList(input)).not.toThrow();
+      const result = parseDeckList(input);
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('handles non-string input gracefully', () => {
+      expect(parseDeckList(null)).toEqual([]);
+      expect(parseDeckList(undefined)).toEqual([]);
+      expect(parseDeckList(123)).toEqual([]);
+    });
+
+    it('ignores comment lines', () => {
+      const input = '# Identity: Jinteki: Personal Evolution\n3 Akamatsu Mem Chip';
+      expect(parseDeckList(input)).toEqual([{ quantity: 3, name: 'Akamatsu Mem Chip' }]);
+    });
+  });
+}


### PR DESCRIPTION
<img src="https://raw.githubusercontent.com/mzpkdev/preemclaud/main/arasaka/assets/banner.svg" />
<img src="https://raw.githubusercontent.com/mzpkdev/preemclaud/main/arasaka/assets/issue-reply.svg" />

<img src="https://raw.githubusercontent.com/mzpkdev/preemclaud/main/arasaka/assets/divider.svg" />

The family has identified a bounded piece of repository work that warrants attention.

**Summary**
The extracted parseDeckList function returns undefined array elements when a card title is absent from allCards. These propagate unchecked into createDeck and cause an immediate crash in createCard. The existing test suite does not cover this path.

**Problem**
In src/scripts/deck.js, parseDeckList maps each parsed card name through allCards.find(c => c.title === cardName). When the title is not found, find returns undefined, which is appended to the result array without filtering. createDeck then iterates the result and passes each element directly to createCard, which immediately accesses cardInfo.title — throwing TypeError: Cannot read properties of undefined. The four tests in src/scripts/deck.test.js supply only card names present in the allCards fixture; the unrecognized-name path is entirely untested. The blank-line and numeric-parse guards added in the prior fix do not address this case.

**Acceptance Criteria**
- parseDeckList filters out entries where the card title is not present in allCards, so the returned array contains no undefined elements.
- A new test in src/scripts/deck.test.js asserts that an entry referencing an unrecognized card name is excluded from the return value.
- A new test asserts that a mixed list — some recognized, some unrecognized — returns only the recognized cards at the correct counts.
- npm test exits 0 with all existing and new tests passing.

**Evidence**
- src/scripts/deck.js: parseDeckList line '.map(cardName => allCards.find(c => c.title === cardName))' — no undefined guard after the find call
- src/scripts/deck.js: createDeck calls parseDeckList then passes each element to createCard without a null check
- src/scripts/deck.test.js: allCards fixture contains only 'Hedge Fund', 'Sure Gamble', 'Ice Wall' — no test exercises a name absent from that set
- src/scripts/card.js: createCard first line accesses cardInfo.title via setAttribute, crashing immediately on undefined cardInfo
- GitHub issue #70: open, covers deck.js parser correctness and test coverage

<sub>Arasaka Queue Planning Division.</sub>

<img src="https://raw.githubusercontent.com/mzpkdev/preemclaud/main/arasaka/assets/footer.svg" />