### PR TITLE
fix: rename stactedToken -> stackedToken and cardIfo -> cardInfo

### DIFF
--- a/src/scripts/game.js
+++ b/src/scripts/game.js
@@ -52,9 +52,9 @@ export const setupGame = () => {
 export const main = async () => {
     try {
         window.allCards = await fetchAllCards().then((cards) =>
-            cards.data.map((cardIfo) => {
-                cardIfo.image = `https://card-images.netrunnerdb.com/v2/large/${cardIfo.code}.jpg`;
-                return cardIfo;
+            cards.data.map((cardInfo) => {
+                cardInfo.image = `https://card-images.netrunnerdb.com/v2/large/${cardInfo.code}.jpg`;
+                return cardInfo;
             }),
         );
     } catch (error) {

--- a/src/scripts/token.js
+++ b/src/scripts/token.js
@@ -158,9 +158,9 @@ function flipToken(tokenElement, key, value) {
         "translate(-50%, -50%) translate(-10px, -10px)";
     tokenElement.replaceChild(newInnerElement, tokenElement.firstElementChild);
 
-    const stactedToken = tokenElement.querySelector(".token");
-    if (stactedToken) {
-        flipToken(stactedToken, key, value);
+    const stackedToken = tokenElement.querySelector(".token");
+    if (stackedToken) {
+        flipToken(stackedToken, key, value);
     }
 }
 


### PR DESCRIPTION
## Summary

Local-variable rename only; no behavior change.

- \`src/scripts/token.js\` (\`flipToken\`, lines 161-163): \`stactedToken\` -> \`stackedToken\`. Matches the intent ('stacked token', i.e. the nested \`.token\` element).
- \`src/scripts/game.js\` (\`cards.data.map\` callback, lines 55-57): \`cardIfo\` -> \`cardInfo\`. Matches \`cardInfo\` used elsewhere in the same file (lines 22, 42) and across \`card.js\` / \`deck.js\`.

Closes #158

## Testing

Renames only — grep confirms zero remaining \`stactedToken\` / \`cardIfo\` occurrences and all call sites were updated consistently.