### PR TITLE
fix(deck): support CRLF deck lists

### DIFF
--- a/src/scripts/deck.js
+++ b/src/scripts/deck.js
@@ -7,7 +7,7 @@ import { shuffle } from "./utils.js";
 export const parseDeckList = (deckListString, allCards) => {
     const names = deckListString
         .trim()
-        .split("\n")
+        .split(/\r?\n|\r/)
         .flatMap((entry) => {
             const trimmed = entry.trim();
             if (!trimmed) return [];

--- a/src/scripts/deck.test.js
+++ b/src/scripts/deck.test.js
@@ -60,6 +60,39 @@ describe("parseDeckList", () => {
         expect(result.matched).toHaveLength(3);
     });
 
+    it("parses Windows CRLF line endings", () => {
+        const result = parseDeckList(
+            "2x Hedge Fund\r\n1x Sure Gamble\r\n3x Ice Wall",
+            allCards,
+        );
+        expect(result.matched).toHaveLength(6);
+        expect(result.failed).toHaveLength(0);
+        expect(
+            result.matched.filter((c) => c.title === "Hedge Fund"),
+        ).toHaveLength(2);
+        expect(
+            result.matched.filter((c) => c.title === "Sure Gamble"),
+        ).toHaveLength(1);
+        expect(
+            result.matched.filter((c) => c.title === "Ice Wall"),
+        ).toHaveLength(3);
+    });
+
+    it("parses bare carriage-return line endings", () => {
+        const result = parseDeckList(
+            "1x Hedge Fund\r2x Sure Gamble",
+            allCards,
+        );
+        expect(result.matched).toHaveLength(3);
+        expect(result.failed).toHaveLength(0);
+        expect(
+            result.matched.filter((c) => c.title === "Hedge Fund"),
+        ).toHaveLength(1);
+        expect(
+            result.matched.filter((c) => c.title === "Sure Gamble"),
+        ).toHaveLength(2);
+    });
+
     it("returns an empty matched array for an entirely empty string", () => {
         const result = parseDeckList("", allCards);
         expect(result.matched).toHaveLength(0);


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Parse deck lists using `\r?\n` or bare `\r` line separators instead of only `\n`.
- Add regression coverage for Windows CRLF deck lists.
- Add regression coverage for bare carriage-return separated lists.

Closes #414

## Testing
- `npm test -- src/scripts/deck.test.js`
- `npm run lint`
- `npm run typecheck`
- `git diff --check`

## CI note
- `arasaka / review` failed because the workflow requires write permissions and this fork PR actor only has read permissions: `Actor does not have write permissions to the repository`. No code/test failure was reported before that permission gate.

## AI assistance disclosure
This draft PR was prepared with AI assistance and manually verified with the commands above.
