### PR TITLE
Guard point bounds helper against nullish elements

### DIFF
--- a/src/scripts/utils.js
+++ b/src/scripts/utils.js
@@ -28,6 +28,8 @@ export function snapToGrid(element, grid = 25) {
 }
 
 export function isPointWithinElement(x, y, element) {
+    if (!element) return false;
+
     const rect = element.getBoundingClientRect();
     return (
         x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom

--- a/src/scripts/utils.test.js
+++ b/src/scripts/utils.test.js
@@ -121,6 +121,11 @@ describe("isPointWithinElement", () => {
         expect(isPointWithinElement(50, 70, el)).toBe(true);
     });
 
+    it("returns false for a nullish element", () => {
+        expect(isPointWithinElement(50, 70, null)).toBe(false);
+        expect(isPointWithinElement(50, 70, undefined)).toBe(false);
+    });
+
     it("returns false for a point to the left of the element", () => {
         expect(isPointWithinElement(5, 70, el)).toBe(false);
     });


### PR DESCRIPTION
## Summary
- return false from isPointWithinElement when the supplied element is null or undefined
- add a regression test covering null and undefined element inputs

## Verification
- npm test -- --reporter=verbose src/scripts/utils.test.js

Closes #499